### PR TITLE
[INT-8998] Aded encoding to the slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 1.0.3 2024-01-05
+
+- Fixed issue when the organization slug has a / in the name
+
 ## 1.0.2 2023-12-13
 
 - Upgraded packages version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-circleci",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A JupiterOne Integration for ingesting data of the CircleCI",
   "repository": {
     "type": "git",

--- a/src/client.ts
+++ b/src/client.ts
@@ -102,6 +102,7 @@ export class APIClient {
     organization: string,
     iteratee: ResourceIteratee<CircleCIPipeline>,
   ): Promise<void> {
+    organization = encodeURIComponent(organization);
     await this.pipelinePaginatedRequest(
       this.withBaseUri(`pipeline?org-slug=${organization}`),
       'GET',


### PR DESCRIPTION
# Description
Added encodeURIComponent since `/` in the Organization name was causing the integration to fail, for the case `gh/StashInvest`