### PR TITLE
INT-10771 Better error handling when making API requests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import {
   IntegrationLogger,
   IntegrationProviderAuthenticationError,
+  IntegrationProviderAuthorizationError,
 } from '@jupiterone/integration-sdk-core';
 import pMap from 'p-map';
 
@@ -79,7 +80,7 @@ export class APIClient {
               'fatal request error, not retrying',
             );
             if (resp.status === 401) {
-              throw new IntegrationProviderAuthenticationError({
+              throw new IntegrationProviderAuthorizationError({
                 statusText: `Encountered authorization error from provider (status=${resp.status})`,
                 endpoint: resp.url,
                 status: resp.status,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,6 @@
 import fetch from 'node-fetch';
 import {
   IntegrationLogger,
-  IntegrationProviderAPIError,
   IntegrationProviderAuthenticationError,
 } from '@jupiterone/integration-sdk-core';
 import pMap from 'p-map';
@@ -69,11 +68,23 @@ export class APIClient {
               this.logger?.warn(serverRetryDelay, 'Retry Delay');
             }
 
-            this.logger?.warn(resp, 're-trying request from fetch');
-
+            this.logger?.warn(
+              { statusCode: resp.status },
+              're-trying request from fetch',
+            );
             throw retryableRequestError(resp);
           } else {
-            this.logger?.warn(resp, 'fatal request error, not retrying');
+            this.logger?.warn(
+              { statusCode: resp.status },
+              'fatal request error, not retrying',
+            );
+            if (resp.status === 401) {
+              throw new IntegrationProviderAuthenticationError({
+                statusText: `Encountered authorization error from provider (status=${resp.status})`,
+                endpoint: resp.url,
+                status: resp.status,
+              });
+            }
             throw fatalRequestError(resp);
           }
         },
@@ -81,7 +92,6 @@ export class APIClient {
           calculateDelay: () => retryDelay,
           maxAttempts: 10,
           handleError: (err, context) => {
-            this.logger?.warn(err, 'retry handle-error');
             if (err.code === 'ECONNRESET') {
               this.logger?.warn(err, 'Encountered ECONNRESET. Retrying.');
             } else if (!err.retryable) {
@@ -94,11 +104,7 @@ export class APIClient {
       return response.json();
     } catch (err) {
       this.logger?.warn(err, 'Could not get Request on API Client');
-      throw new IntegrationProviderAPIError({
-        endpoint: endpoint,
-        status: err.status,
-        statusText: err.statusText,
-      });
+      throw err;
     }
   }
 
@@ -131,12 +137,7 @@ export class APIClient {
       } while (hasNext);
     } catch (err) {
       this.logger?.warn(err, 'Could not get Pipeline Paginated Request');
-      throw new IntegrationProviderAPIError({
-        cause: new Error(err.message),
-        endpoint: uri,
-        status: err.status,
-        statusText: err.message,
-      });
+      throw err;
     }
   }
 


### PR DESCRIPTION
- removed some unnecessary log statements
- we were previously always throwing an Integration Provider API error. There are scenarios like 401s where we should be throwing another type of error.
- for 401s, throw an auth error instead.